### PR TITLE
Add Genesis 2 — CPU-only Cascade MoE for edge AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1210,6 +1210,8 @@ simulator focused on mobile cloud/edge/iot infrastructures.
   device in the network (systems heterogeneity), and (2) non-identically
   distributed data across the network (statistical heterogeneity).
 
+
+- [Genesis 2](https://github.com/larionovavi-stack/genesis2-cascade-moe) - CPU-only neural network for edge deployment. Cascade MoE with 18ms inference, 3.5GB model, no GPU required. Ideal for edge AI applications.
 - [GNN-RL pipleline](https://gnn-rl.readthedocs.io/en/latest/): GNN-RL pipleline is a
   toolkit to help users extract topology information through reinforcement
   learning task (e.g., topology-aware neural network compression and job


### PR DESCRIPTION
## Summary

Adds **Genesis 2** to the **Edge-AI frameworks** section (alphabetical order, between FedProx and GNN-RL).

- [Genesis 2](https://github.com/larionovavi-stack/genesis2-cascade-moe) is a CPU-only neural network using Cascade Mixture-of-Experts architecture
- **18ms inference latency**, **3.5 GB model size**, **no GPU required**
- Designed specifically for edge and resource-constrained deployment scenarios
- Written in Python, runs on standard x86/ARM hardware

## Why it fits

This list already includes frameworks for edge AI inference (TFLite, MNN, NCNN, etc.). Genesis 2 complements these with a novel architecture (Cascade MoE) that achieves low latency on CPU-only edge devices — no cloud dependency, no GPU, no specialized hardware.

## Checklist

- [x] Entry is in alphabetical order within the Edge-AI frameworks section
- [x] Link is valid and points to the public repository
- [x] Description is concise and factual